### PR TITLE
Update 12-12-2024

### DIFF
--- a/decorate/Ammo/CrossbowAmmoDropped_Toby.dec
+++ b/decorate/Ammo/CrossbowAmmoDropped_Toby.dec
@@ -6,7 +6,7 @@ States
 	{
 	Spawn:
 		AMC1 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_Arrows", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMC1 AA 25 Bright
+		AMC1 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/CrossbowAmmo_Toby.dec
+++ b/decorate/Ammo/CrossbowAmmo_Toby.dec
@@ -8,7 +8,7 @@ States
 	{
 	Spawn:
 		AMC1 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_Arrows", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMC1 AA 25 Bright
+		AMC1 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/CrossbowHefty_Toby.dec
+++ b/decorate/Ammo/CrossbowHefty_Toby.dec
@@ -10,7 +10,6 @@ States
 		AMC2 ABC 3 Bright
 		AMC2 ABC 3 Bright
 		AMC2 ABC 3 Bright
-		AMC2 ABC 3 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/GoldWandAmmoDropped_Toby.dec
+++ b/decorate/Ammo/GoldWandAmmoDropped_Toby.dec
@@ -6,7 +6,7 @@ States
 	{
 	Spawn:
 		AMG1 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_Crystal", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMG1 AA 25 Bright
+		AMG1 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/GoldWandAmmo_Toby.dec
+++ b/decorate/Ammo/GoldWandAmmo_Toby.dec
@@ -8,7 +8,7 @@ States
 	{
 	Spawn:
 		AMG1 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_Crystal", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMG1 AA 25 Bright
+		AMG1 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/GoldWandHefty_Toby.dec
+++ b/decorate/Ammo/GoldWandHefty_Toby.dec
@@ -10,7 +10,6 @@ States
 		AMG2 ABC 3 Bright
 		AMG2 ABC 3 Bright
 		AMG2 ABC 3 Bright
-		AMG2 ABC 3 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/HellStaffAmmoDropped_Toby.dec
+++ b/decorate/Ammo/HellStaffAmmoDropped_Toby.dec
@@ -10,7 +10,6 @@ States
 		AMS1 AB 5 Bright
 		AMS1 AB 5 Bright
 		AMS1 AB 5 Bright
-		AMS1 AB 5 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/HellStaffAmmo_Toby.dec
+++ b/decorate/Ammo/HellStaffAmmo_Toby.dec
@@ -12,7 +12,6 @@ States
 		AMS1 AB 5 Bright
 		AMS1 AB 5 Bright
 		AMS1 AB 5 Bright
-		AMS1 AB 5 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/HellStaffHefty_Toby.dec
+++ b/decorate/Ammo/HellStaffHefty_Toby.dec
@@ -10,7 +10,6 @@ States
 		AMS2 AB 5 Bright
 		AMS2 AB 5 Bright
 		AMS2 AB 5 Bright
-		AMS2 AB 5 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/MaceAmmo_Toby.dec
+++ b/decorate/Ammo/MaceAmmo_Toby.dec
@@ -8,7 +8,7 @@ States
 	{
 	Spawn:
 		AMM1 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_SmallBallsOfSteel", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMM1 AA 25 Bright
+		AMM1 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/MaceHefty_Toby.dec
+++ b/decorate/Ammo/MaceHefty_Toby.dec
@@ -6,7 +6,7 @@ States
 	{
 	Spawn:
 		AMM2 A 1 Bright A_SpawnItemEx("AmmoPickupChecker_BigBallsOfSteel", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMM2 AA 25 Bright
+		AMM2 AA 18 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/PhoenixRodAmmo_Toby.dec
+++ b/decorate/Ammo/PhoenixRodAmmo_Toby.dec
@@ -7,12 +7,14 @@ ACTOR PhoenixRodAmmo_Toby : CustomInventory replaces PhoenixRodAmmo
 States
 	{
 	Spawn:
-		AMP1 A 3 Bright A_SpawnItemEx("AmmoPickupChecker_InfernoSmall", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMP1 BC 3 Bright
-		AMP1 ABC 3 Bright
-		AMP1 ABC 3 Bright
-		AMP1 ABC 3 Bright
-		AMP1 ABC 3 Bright
+		AMP1 A 2 Bright A_SpawnItemEx("AmmoPickupChecker_InfernoSmall", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		AMP1 BC 2 Bright
+		AMP1 ABC 2 Bright
+		AMP1 ABC 2 Bright
+		AMP1 ABC 2 Bright
+		AMP1 ABC 2 Bright
+		AMP1 ABC 2 Bright
+		AMP1 ABC 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Ammo/PhoenixRodHefty_Toby.dec
+++ b/decorate/Ammo/PhoenixRodHefty_Toby.dec
@@ -5,12 +5,14 @@ ACTOR PhoenixRodHefty_Toby : CustomInventory replaces PhoenixRodHefty
 States
 	{
 	Spawn:
-		AMP2 A 3 Bright A_SpawnItemEx("AmmoPickupChecker_InfernoBig", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-		AMP2 BC 3 Bright
-		AMP2 ABC 3 Bright
-		AMP2 ABC 3 Bright
-		AMP2 ABC 3 Bright
-		AMP2 ABC 3 Bright
+		AMP2 A 2 Bright A_SpawnItemEx("AmmoPickupChecker_InfernoBig", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
+		AMP2 BC 2 Bright
+		AMP2 ABC 2 Bright
+		AMP2 ABC 2 Bright
+		AMP2 ABC 2 Bright
+		AMP2 ABC 2 Bright
+		AMP2 ABC 2 Bright
+		AMP2 ABC 2 Bright
 		Loop
 	Pickup:
 		TNT1 A 1 A_JumpIfInventory("BagOfHolding_Toby", 1, "HasBP")

--- a/decorate/Pickups/BagOfHolding_Toby.dec
+++ b/decorate/Pickups/BagOfHolding_Toby.dec
@@ -27,7 +27,7 @@ ACTOR BagOfHolding_Giver : CustomInventory replaces BagOfHolding
     {
     Spawn:
         BAGH A 1 A_SpawnItemEx("BPackPickupChecker", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        BAGH AA 25
+        BAGH AA 18
         Loop
     Pickup:
         TNT1 A 1 A_GiveInventory("BagOfHolding_Toby", 1)

--- a/decorate/Weapons/Crossbow_Toby.dec
+++ b/decorate/Weapons/Crossbow_Toby.dec
@@ -13,7 +13,7 @@ ACTOR Crossbow_Toby : Crossbow
 	{
 	Spawn:
 		WBOW A 1 A_SpawnItemEx("WeaponPickupChecker_Crossbow", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WBOW AA 25 
+        WBOW AA 18 
         Loop
 	Ready:
 		CRBW AAAABBBBCCCC 1 A_WeaponReady
@@ -80,7 +80,7 @@ ACTOR Crossbow_Giver : CustomInventory replaces Crossbow
     {
     Spawn:
         WBOW A 1 A_SpawnItemEx("WeaponPickupChecker_Crossbow", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WBOW AA 25 
+        WBOW AA 18 
         Loop
     Pickup:
 		TNT1 A 1 A_JumpIfInventory("Crossbow_Toby", 1, "HasCrossbow")

--- a/decorate/Weapons/DragonClaw_Toby.dec
+++ b/decorate/Weapons/DragonClaw_Toby.dec
@@ -10,7 +10,7 @@ ACTOR DragonClaw_Toby : Blaster
 	{
 	Spawn:
 		WBLS A 1 A_SpawnItemEx("WeaponPickupChecker_DragonClaw", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WBLS AA 25 
+        WBLS AA 20
         Loop
 	Ready:
 		BLSR A 1 A_WeaponReady
@@ -65,7 +65,7 @@ ACTOR DragonClaw_Giver : CustomInventory replaces Blaster
     {
     Spawn:
         WBLS A 1 A_SpawnItemEx("WeaponPickupChecker_DragonClaw", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WBLS AA 25 
+        WBLS AA 20
         Loop
     Pickup:
 		TNT1 A 1 A_JumpIfInventory("DragonClaw_Toby", 1, "HasDragonClaw")

--- a/decorate/Weapons/FireMace_Toby.dec
+++ b/decorate/Weapons/FireMace_Toby.dec
@@ -9,7 +9,7 @@ ACTOR FireMace_Toby : Mace
 	{
 	Spawn:
 		WMCE A 1 A_SpawnItemEx("WeaponPickupChecker_Mace", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WMCE AA 25 
+        WMCE AA 18
         Loop
 	Ready:
 		MACE A 1 A_WeaponReady
@@ -62,7 +62,7 @@ ACTOR FireMace_Giver : CustomInventory replaces Mace
     {
     Spawn:
         WMCE A 1 A_SpawnItemEx("WeaponPickupChecker_Mace", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WMCE AA 25 
+        WMCE AA 18 
         Loop
     Pickup:
 		TNT1 A 1 A_JumpIfInventory("FireMace_Toby", 1, "HasMace")

--- a/decorate/Weapons/Gauntlets_Toby.dec
+++ b/decorate/Weapons/Gauntlets_Toby.dec
@@ -7,7 +7,7 @@ ACTOR Gauntlets_Toby : Gauntlets replaces Gauntlets
 	{
 	Spawn:
 		WGNT A 1 A_SpawnItemEx("WeaponPickupChecker_Gauntlets", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WGNT AA 25
+        WGNT AA 18
         Loop
 	Ready:
 		GAUN A 1 A_WeaponReady

--- a/decorate/Weapons/HellStaff_Toby.dec
+++ b/decorate/Weapons/HellStaff_Toby.dec
@@ -9,7 +9,7 @@ ACTOR HellStaff_Toby : SkullRod
 	{
 	Spawn:
 		WSKL A 1 A_SpawnItemEx("WeaponPickupChecker_HellStaff", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WSKL AA 25 
+        WSKL AA 20
         Loop
 	Ready:
 		HROD A 1 A_WeaponReady
@@ -65,7 +65,7 @@ ACTOR HellStaff_Giver : CustomInventory replaces SkullRod
     {
     Spawn:
         WSKL A 1 A_SpawnItemEx("WeaponPickupChecker_HellStaff", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WSKL AA 25 
+        WSKL AA 20
         Loop
     Pickup:
 		TNT1 A 1 A_JumpIfInventory("HellStaff_Toby", 1, "HasHellStaff")

--- a/decorate/Weapons/PhoenixRod_Toby.dec
+++ b/decorate/Weapons/PhoenixRod_Toby.dec
@@ -9,7 +9,7 @@ ACTOR PhoenixRod_Toby : PhoenixRod
 	{
 	Spawn:
 		WPHX A 1 A_SpawnItemEx("WeaponPickupChecker_PhoenixRod", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WPHX AA 25 
+        WPHX AA 18
         Loop
 	Ready:
 		PHNX A 1 A_WeaponReady
@@ -63,7 +63,7 @@ ACTOR PhoenixRod_Giver : CustomInventory replaces PhoenixRod
     {
     Spawn:
         WPHX A 1 A_SpawnItemEx("WeaponPickupChecker_PhoenixRod", 0, 0, 0, 0, 0, 0, 0, SXF_NOCHECKPOSITION, 0)
-        WPHX AA 25 
+        WPHX AA 18
         Loop
     Pickup:
 		TNT1 A 1 A_JumpIfInventory("PhoenixRod_Toby", 1, "HasPhoenixRod")


### PR DESCRIPTION
Modified the frequency of the weapon and ammo beacon sounds. As per stormdragon's recommendations, beacon frequency should be every 1 - 1.25 seconds. Some of the weapons and ammo needed their frequency to be about 1.25 - 1.5 seconds. Everything should be balanced, though.